### PR TITLE
Added command line option to change log level

### DIFF
--- a/wmediumd/config.c
+++ b/wmediumd/config.c
@@ -59,10 +59,12 @@ int load_config(struct wmediumd *ctx, const char *file)
 
 	/*read the file*/
 	if (!config_read_file(cf, file)) {
-		printf("Error loading file %s at line:%d, reason: %s\n",
-		       file,
-		       config_error_line(cf),
-		       config_error_text(cf));
+		if (ctx->log_error) {
+			printf("Error loading file %s at line:%d, reason: %s\n",
+				file,
+				config_error_line(cf),
+				config_error_text(cf));
+		}
 		config_destroy(cf);
 		exit(EXIT_FAILURE);
 	}
@@ -70,7 +72,9 @@ int load_config(struct wmediumd *ctx, const char *file)
 	ids = config_lookup(cf, "ifaces.ids");
 	count_ids = config_setting_length(ids);
 
-	printf("#_if = %d\n", count_ids);
+	if (ctx->log_startup) {
+		printf("#_if = %d\n", count_ids);
+	}
 
 	/* Fill the mac_addr */
 	for (i = 0; i < count_ids; i++) {
@@ -80,7 +84,9 @@ int load_config(struct wmediumd *ctx, const char *file)
 
 		station = malloc(sizeof(*station));
 		if (!station) {
-			fprintf(stderr, "Out of memory!\n");
+			if (ctx->log_error) {
+				fprintf(stderr, "Out of memory!\n");
+			}
 			exit(1);
 		}
 		station->index = i;
@@ -89,14 +95,18 @@ int load_config(struct wmediumd *ctx, const char *file)
 		station_init_queues(station);
 		list_add_tail(&station->list, &ctx->stations);
 
-		printf("Added station %d: " MAC_FMT "\n", i, MAC_ARGS(addr));
+		if (ctx->log_startup) {
+			printf("Added station %d: " MAC_FMT "\n", i, MAC_ARGS(addr));
+		}
 	}
 	ctx->num_stas = count_ids;
 
 	/* create link quality matrix */
 	ctx->snr_matrix = calloc(sizeof(int), count_ids * count_ids);
 	if (!ctx->snr_matrix) {
-		fprintf(stderr, "Out of memory!\n");
+		if (ctx->log_error) {
+			fprintf(stderr, "Out of memory!\n");
+		}
 		exit(1);
 	}
 
@@ -111,7 +121,9 @@ int load_config(struct wmediumd *ctx, const char *file)
 
 		link = config_setting_get_elem(links, i);
 		if (config_setting_length(link) != 3) {
-			fprintf(stderr, "Invalid link: expected (int,int,int)\n");
+			if (ctx->log_error) {
+				fprintf(stderr, "Invalid link: expected (int,int,int)\n");
+			}
 			continue;
 		}
 		start = config_setting_get_int_elem(link, 0);
@@ -120,8 +132,10 @@ int load_config(struct wmediumd *ctx, const char *file)
 
 		if (start < 0 || start >= ctx->num_stas ||
 		    end < 0 || end >= ctx->num_stas) {
-			fprintf(stderr, "Invalid link [%d,%d,%d]: index out of range\n",
-				start, end, snr);
+			if (ctx->log_error) {
+				fprintf(stderr, "Invalid link [%d,%d,%d]: index out of range\n",
+						start, end, snr);
+            }
 			continue;
 		}
 		ctx->snr_matrix[ctx->num_stas * start + end] = snr;

--- a/wmediumd/config.c
+++ b/wmediumd/config.c
@@ -59,12 +59,10 @@ int load_config(struct wmediumd *ctx, const char *file)
 
 	/*read the file*/
 	if (!config_read_file(cf, file)) {
-		if (ctx->log_error) {
-			printf("Error loading file %s at line:%d, reason: %s\n",
+		w_logf(ctx, LOG_ERR, "Error loading file %s at line:%d, reason: %s\n",
 				file,
 				config_error_line(cf),
 				config_error_text(cf));
-		}
 		config_destroy(cf);
 		exit(EXIT_FAILURE);
 	}
@@ -72,9 +70,7 @@ int load_config(struct wmediumd *ctx, const char *file)
 	ids = config_lookup(cf, "ifaces.ids");
 	count_ids = config_setting_length(ids);
 
-	if (ctx->log_startup) {
-		printf("#_if = %d\n", count_ids);
-	}
+	w_logf(ctx, LOG_NOTICE, "#_if = %d\n", count_ids);
 
 	/* Fill the mac_addr */
 	for (i = 0; i < count_ids; i++) {
@@ -84,9 +80,7 @@ int load_config(struct wmediumd *ctx, const char *file)
 
 		station = malloc(sizeof(*station));
 		if (!station) {
-			if (ctx->log_error) {
-				fprintf(stderr, "Out of memory!\n");
-			}
+			w_flogf(ctx, LOG_ERR, stderr, "Out of memory!\n");
 			exit(1);
 		}
 		station->index = i;
@@ -95,18 +89,14 @@ int load_config(struct wmediumd *ctx, const char *file)
 		station_init_queues(station);
 		list_add_tail(&station->list, &ctx->stations);
 
-		if (ctx->log_startup) {
-			printf("Added station %d: " MAC_FMT "\n", i, MAC_ARGS(addr));
-		}
+		w_logf(ctx, LOG_NOTICE, "Added station %d: " MAC_FMT "\n", i, MAC_ARGS(addr));
 	}
 	ctx->num_stas = count_ids;
 
 	/* create link quality matrix */
 	ctx->snr_matrix = calloc(sizeof(int), count_ids * count_ids);
 	if (!ctx->snr_matrix) {
-		if (ctx->log_error) {
-			fprintf(stderr, "Out of memory!\n");
-		}
+		w_flogf(ctx, LOG_ERR, stderr, "Out of memory!\n");
 		exit(1);
 	}
 
@@ -121,9 +111,7 @@ int load_config(struct wmediumd *ctx, const char *file)
 
 		link = config_setting_get_elem(links, i);
 		if (config_setting_length(link) != 3) {
-			if (ctx->log_error) {
-				fprintf(stderr, "Invalid link: expected (int,int,int)\n");
-			}
+			w_flogf(ctx, LOG_ERR, stderr, "Invalid link: expected (int,int,int)\n");
 			continue;
 		}
 		start = config_setting_get_int_elem(link, 0);
@@ -132,10 +120,8 @@ int load_config(struct wmediumd *ctx, const char *file)
 
 		if (start < 0 || start >= ctx->num_stas ||
 		    end < 0 || end >= ctx->num_stas) {
-			if (ctx->log_error) {
-				fprintf(stderr, "Invalid link [%d,%d,%d]: index out of range\n",
-						start, end, snr);
-            }
+			w_flogf(ctx, LOG_ERR, stderr, "Invalid link [%d,%d,%d]: index out of range\n",
+					start, end, snr);
 			continue;
 		}
 		ctx->snr_matrix[ctx->num_stas * start + end] = snr;

--- a/wmediumd/wmediumd.c
+++ b/wmediumd/wmediumd.c
@@ -724,10 +724,10 @@ void print_help(int exval)
 
 	printf("  -l LOG_LVL      set the logging level\n");
 	printf("                  LOG_LVL: RFC 5424 severity, values 0 - 7\n");
-	printf("                  3 and below: errors are logged\n");
-	printf("                  5 and below: startup msgs are logged\n");
-	printf("                  6 and below: dropped packets are logged\n");
-	printf("                  7          : all packets will be logged\n");
+	printf("                  >= 3: errors are logged\n");
+	printf("                  >= 5: startup msgs are logged\n");
+	printf("                  >= 6: dropped packets are logged\n");
+	printf("                  == 7: all packets will be logged\n");
 	printf("  -c FILE         set input config file\n");
 
 	exit(exval);

--- a/wmediumd/wmediumd.c
+++ b/wmediumd/wmediumd.c
@@ -30,6 +30,8 @@
 #include <signal.h>
 #include <event.h>
 #include <sys/timerfd.h>
+#include <errno.h>
+#include <limits.h>
 
 #include "wmediumd.h"
 #include "ieee80211.h"
@@ -48,6 +50,26 @@ static inline int pkt_duration(int len, int rate)
 {
 	/* preamble + signal + t_sym * n_sym, rate in 100 kbps */
 	return 16 + 4 + 4 * div_round((16 + 8 * len + 6) * 10, 4 * rate);
+}
+
+int w_logf(struct wmediumd *ctx, u8 level, const char *format, ...)
+{
+    va_list(args);
+    va_start(args, format);
+	if (ctx->log_lvl >= level) {
+		return vprintf(format, args);
+	}
+	return -1;
+}
+
+int w_flogf(struct wmediumd *ctx, u8 level, FILE *stream, const char *format, ...)
+{
+    va_list(args);
+    va_start(args, format);
+	if (ctx->log_lvl >= level) {
+		return vfprintf(stream, format, args);
+	}
+	return -1;
 }
 
 static void wqueue_init(struct wqueue *wqueue, int cw_min, int cw_max)
@@ -330,9 +352,7 @@ int send_tx_info_frame_nl(struct wmediumd *ctx,
 
 	msg = nlmsg_alloc();
 	if (!msg) {
-		if (ctx->log_error) {
-			printf("Error allocating new message MSG!\n");
-		}
+		w_logf(ctx, LOG_ERR, "Error allocating new message MSG!\n");
 		return -1;
 	}
 
@@ -340,9 +360,7 @@ int send_tx_info_frame_nl(struct wmediumd *ctx,
 			genl_family_get_id(ctx->family), 0,
 			NLM_F_REQUEST, HWSIM_CMD_TX_INFO_FRAME,
 			VERSION_NR) == NULL) {
-		if (ctx->log_error) {
-			printf("%s: genlmsg_put failed\n", __func__);
-		}
+		w_logf(ctx, LOG_ERR, "%s: genlmsg_put failed\n", __func__);
 		ret = -1;
 		goto out;
 	}
@@ -355,18 +373,14 @@ int send_tx_info_frame_nl(struct wmediumd *ctx,
 		    IEEE80211_TX_MAX_RATES * sizeof(struct hwsim_tx_rate),
 		    tx_attempts) ||
 	    nla_put_u64(msg, HWSIM_ATTR_COOKIE, cookie)) {
-		if (ctx->log_error) {
-			printf("%s: Failed to fill a payload\n", __func__);
-		}
+		w_logf(ctx, LOG_ERR, "%s: Failed to fill a payload\n", __func__);
 		ret = -1;
 		goto out;
 	}
 
 	ret = nl_send_auto_complete(sock, msg);
 	if (ret < 0) {
-		if (ctx->log_error) {
-			printf("%s: nl_send_auto failed\n", __func__);
-		}
+		w_logf(ctx, LOG_ERR, "%s: nl_send_auto failed\n", __func__);
 		ret = -1;
 		goto out;
 	}
@@ -389,9 +403,7 @@ int send_cloned_frame_msg(struct wmediumd *ctx, struct station *dst,
 
 	msg = nlmsg_alloc();
 	if (!msg) {
-		if (ctx->log_error) {
-			printf("Error allocating new message MSG!\n");
-		}
+		w_logf(ctx, LOG_ERR, "Error allocating new message MSG!\n");
 		return -1;
 	}
 
@@ -399,9 +411,7 @@ int send_cloned_frame_msg(struct wmediumd *ctx, struct station *dst,
 			genl_family_get_id(ctx->family), 0,
 			NLM_F_REQUEST, HWSIM_CMD_FRAME,
 			VERSION_NR) == NULL) {
-		if (ctx->log_error) {
-			printf("%s: genlmsg_put failed\n", __func__);
-		}
+		w_logf(ctx, LOG_ERR, "%s: genlmsg_put failed\n", __func__);
 		ret = -1;
 		goto out;
 	}
@@ -411,23 +421,17 @@ int send_cloned_frame_msg(struct wmediumd *ctx, struct station *dst,
 	    nla_put(msg, HWSIM_ATTR_FRAME, data_len, data) ||
 	    nla_put_u32(msg, HWSIM_ATTR_RX_RATE, 1) ||
 	    nla_put_u32(msg, HWSIM_ATTR_SIGNAL, -50)) {
-		if (ctx->log_error) {
-			printf("%s: Failed to fill a payload\n", __func__);
-		}
+		w_logf(ctx, LOG_ERR, "%s: Failed to fill a payload\n", __func__);
 		ret = -1;
 		goto out;
 	}
 
-	if (ctx->log_info) {
-		printf("cloned msg dest " MAC_FMT " (radio: " MAC_FMT ") len %d\n",
-			   MAC_ARGS(dst->addr), MAC_ARGS(dst->hwaddr), data_len);
-	}
+	w_logf(ctx, LOG_DEBUG, "cloned msg dest " MAC_FMT " (radio: " MAC_FMT ") len %d\n",
+		   MAC_ARGS(dst->addr), MAC_ARGS(dst->hwaddr), data_len);
 
 	ret = nl_send_auto_complete(sock, msg);
 	if (ret < 0) {
-		if (ctx->log_error) {
-			printf("%s: nl_send_auto failed\n", __func__);
-		}
+		w_logf(ctx, LOG_ERR, "%s: nl_send_auto failed\n", __func__);
 		ret = -1;
 		goto out;
 	}
@@ -466,11 +470,9 @@ void deliver_frame(struct wmediumd *ctx, struct frame *frame)
 							    rate_idx, frame->data_len);
 
 				if (drand48() <= error_prob) {
-					if (ctx->log_drops) {
-						printf("Dropped mcast from "
-							   MAC_FMT " to " MAC_FMT " at receiver\n",
-							   MAC_ARGS(src), MAC_ARGS(station->addr));
-					}
+					w_logf(ctx, LOG_INFO, "Dropped mcast from "
+						   MAC_FMT " to " MAC_FMT " at receiver\n",
+						   MAC_ARGS(src), MAC_ARGS(station->addr));
 					continue;
 				}
 
@@ -525,20 +527,16 @@ void deliver_expired_frames(struct wmediumd *ctx)
 				q_ct[i]++;
 			}
 		}
-		if (ctx->log_info) {
-			printf("[" TIME_FMT "] Station " MAC_FMT
-				   " BK %d BE %d VI %d VO %d\n",
-				   TIME_ARGS(&now), MAC_ARGS(station->addr),
-				   q_ct[IEEE80211_AC_BK], q_ct[IEEE80211_AC_BE],
-				   q_ct[IEEE80211_AC_VI], q_ct[IEEE80211_AC_VO]);
-		}
+		w_logf(ctx, LOG_DEBUG, "[" TIME_FMT "] Station " MAC_FMT
+					   " BK %d BE %d VI %d VO %d\n",
+			   TIME_ARGS(&now), MAC_ARGS(station->addr),
+			   q_ct[IEEE80211_AC_BK], q_ct[IEEE80211_AC_BE],
+			   q_ct[IEEE80211_AC_VI], q_ct[IEEE80211_AC_VO]);
 
 		for (i = 0; i < IEEE80211_NUM_ACS; i++)
 			deliver_expired_frames_queue(ctx, &station->queues[i].frames, &now);
 	}
-	if (ctx->log_info) {
-		printf("\n\n");
-	}
+	w_logf(ctx, LOG_DEBUG, "\n\n");
 }
 
 static
@@ -547,10 +545,8 @@ int nl_err_cb(struct sockaddr_nl *nla, struct nlmsgerr *nlerr, void *arg)
 	struct genlmsghdr *gnlh = nlmsg_data(&nlerr->msg);
 	struct wmediumd *ctx = arg;
 
-	if (ctx->log_error) {
-		fprintf(stderr, "nl: cmd %d, seq %d: %s\n", gnlh->cmd,
-				nlerr->msg.nlmsg_seq, strerror(abs(nlerr->error)));
-	}
+	w_flogf(ctx, LOG_ERR, stderr, "nl: cmd %d, seq %d: %s\n", gnlh->cmd,
+			nlerr->msg.nlmsg_seq, strerror(abs(nlerr->error)));
 
 	return NL_SKIP;
 }
@@ -599,9 +595,7 @@ static int process_messages_cb(struct nl_msg *msg, void *arg)
 
 			sender = get_station_by_addr(ctx, src);
 			if (!sender) {
-				if (ctx->log_error) {
-					fprintf(stderr, "Unable to find sender station " MAC_FMT "\n", MAC_ARGS(src));
-				}
+				w_flogf(ctx, LOG_ERR, stderr, "Unable to find sender station " MAC_FMT "\n", MAC_ARGS(src));
 				goto out;
 			}
 			memcpy(sender->hwaddr, hwaddr, ETH_ALEN);
@@ -637,9 +631,7 @@ int send_register_msg(struct wmediumd *ctx)
 
 	msg = nlmsg_alloc();
 	if (!msg) {
-		if (ctx->log_error) {
-			printf("Error allocating new message MSG!\n");
-		}
+		w_logf(ctx, LOG_ERR, "Error allocating new message MSG!\n");
 		return -1;
 	}
 
@@ -647,18 +639,14 @@ int send_register_msg(struct wmediumd *ctx)
 			genl_family_get_id(ctx->family), 0,
 			NLM_F_REQUEST, HWSIM_CMD_REGISTER,
 			VERSION_NR) == NULL) {
-		if (ctx->log_error) {
-			printf("%s: genlmsg_put failed\n", __func__);
-		}
+		w_logf(ctx, LOG_ERR, "%s: genlmsg_put failed\n", __func__);
 		ret = -1;
 		goto out;
 	}
 
 	ret = nl_send_auto_complete(sock, msg);
 	if (ret < 0) {
-		if (ctx->log_error) {
-			printf("%s: nl_send_auto failed\n", __func__);
-		}
+		w_logf(ctx, LOG_ERR, "%s: nl_send_auto failed\n", __func__);
 		ret = -1;
 		goto out;
 	}
@@ -686,17 +674,13 @@ static int init_netlink(struct wmediumd *ctx)
 
 	ctx->cb = nl_cb_alloc(NL_CB_CUSTOM);
 	if (!ctx->cb) {
-		if (ctx->log_error) {
-			printf("Error allocating netlink callbacks\n");
-		}
+		w_logf(ctx, LOG_ERR, "Error allocating netlink callbacks\n");
 		return -1;
 	}
 
 	sock = nl_socket_alloc_cb(ctx->cb);
 	if (!sock) {
-		if (ctx->log_error) {
-			printf("Error allocating netlink socket\n");
-		}
+		w_logf(ctx, LOG_ERR, "Error allocating netlink socket\n");
 		return -1;
 	}
 
@@ -704,26 +688,20 @@ static int init_netlink(struct wmediumd *ctx)
 
 	ret = genl_connect(sock);
 	if (ret < 0) {
-		if (ctx->log_error) {
-			printf("Error connecting netlink socket ret=%d\n", ret);
-		}
+		w_logf(ctx, LOG_ERR, "Error connecting netlink socket ret=%d\n", ret);
 		return -1;
 	}
 
 	ret = genl_ctrl_alloc_cache(sock, &ctx->cache);
 	if (ret < 0) {
-		if (ctx->log_error) {
-			printf("Error allocationg netlink cache ret=%d\n", ret);
-		}
+		w_logf(ctx, LOG_ERR, "Error allocationg netlink cache ret=%d\n", ret);
 		return -1;
 	}
 
 	ctx->family = genl_ctrl_search_by_name(ctx->cache, "MAC80211_HWSIM");
 
 	if (!ctx->family) {
-		if (ctx->log_error) {
-			printf("Family MAC80211_HWSIM not registered\n");
-		}
+		w_logf(ctx, LOG_ERR, "Family MAC80211_HWSIM not registered\n");
 		return -1;
 	}
 
@@ -745,12 +723,11 @@ void print_help(int exval)
 	printf("  -V              print version and exit\n\n");
 
 	printf("  -l LOG_LVL      set the logging level\n");
-	printf("                  LOG_LVL:\n");
-	printf("                  q: quiet, do not log anything when running\n");
-	printf("                  e: error, only log errors\n");
-	printf("                  s: startup, log errors and startup msgs\n");
-	printf("                  d: drops, log errors and startup msgs and packet drops\n");
-	printf("                  f: full (default), log everything\n");
+	printf("                  LOG_LVL: RFC 5424 severity, values 0 - 7\n");
+	printf("                  3 and below: errors are logged\n");
+	printf("                  5 and below: startup msgs are logged\n");
+	printf("                  6 and below: dropped packets are logged\n");
+	printf("                  7          : all packets will be logged\n");
 	printf("  -c FILE         set input config file\n");
 
 	exit(exval);
@@ -779,10 +756,9 @@ int main(int argc, char *argv[])
 		print_help(EXIT_FAILURE);
 	}
 
-	ctx.log_info = true;
-	ctx.log_drops = true;
-	ctx.log_startup = true;
-	ctx.log_error = true;
+	ctx.log_lvl = 7;
+	unsigned long int parse_log_lvl;
+	char* parse_end_token;
 
 	while ((opt = getopt(argc, argv, "hVc:l:")) != -1) {
 		switch (opt) {
@@ -795,7 +771,6 @@ int main(int argc, char *argv[])
 			exit(EXIT_SUCCESS);
 			break;
 		case 'c':
-			printf("Input configuration file: %s\n", optarg);
 			config_file = optarg;
 			break;
 		case ':':
@@ -804,24 +779,13 @@ int main(int argc, char *argv[])
 			print_help(EXIT_FAILURE);
 			break;
 		case 'l':
-			switch(optarg[0]) {
-				case 'f':
-					break;
-				case 'q':
-					ctx.log_error = false;
-				case 'e':
-					ctx.log_startup = false;
-				case 's':
-					ctx.log_drops = false;
-				case 'd':
-					ctx.log_info = false;
-					break;
-				default:
-					printf("wmediumd: Error - No such logging setting: "
-								   "%c\n\n", optarg[0]);
-					print_help(EXIT_FAILURE);
-					break;
+			parse_log_lvl = strtoul(optarg, &parse_end_token, 10);
+			if ((parse_log_lvl == ULONG_MAX && errno == ERANGE) || optarg == parse_end_token || parse_log_lvl > 7) {
+				printf("wmediumd: Error - Invalid RFC 5424 severity level: "
+							   "%s\n\n", optarg);
+				print_help(EXIT_FAILURE);
 			}
+			ctx.log_lvl = parse_log_lvl;
 			break;
 		case '?':
 			printf("wmediumd: Error - No such option: "
@@ -839,6 +803,8 @@ int main(int argc, char *argv[])
 		printf("%s: config file must be supplied\n", argv[0]);
 		print_help(EXIT_FAILURE);
 	}
+
+	w_logf(&ctx, LOG_NOTICE, "Input configuration file: %s\n", config_file);
 
 	INIT_LIST_HEAD(&ctx.stations);
 	load_config(&ctx, config_file);
@@ -861,9 +827,7 @@ int main(int argc, char *argv[])
 
 	/* register for new frames */
 	if (send_register_msg(&ctx) == 0) {
-		if (ctx.log_startup) {
-			printf("REGISTER SENT!\n");
-		}
+		w_logf(&ctx, LOG_NOTICE, "REGISTER SENT!\n");
 	}
 
 	/* enter libevent main loop */

--- a/wmediumd/wmediumd.c
+++ b/wmediumd/wmediumd.c
@@ -717,7 +717,7 @@ static int init_netlink(struct wmediumd *ctx)
 void print_help(int exval)
 {
 	printf("wmediumd v%s - a wireless medium simulator\n", VERSION_STR);
-	printf("wmediumd [-h] [-V] [-l LOG_LVL] [-c FILE]\n\n");
+	printf("wmediumd [-h] [-V] [-l LOG_LVL] -c FILE\n\n");
 
 	printf("  -h              print this help and exit\n");
 	printf("  -V              print version and exit\n\n");

--- a/wmediumd/wmediumd.h
+++ b/wmediumd/wmediumd.h
@@ -76,6 +76,11 @@ struct wmediumd {
 	struct nl_cb *cb;
 	struct nl_cache *cache;
 	struct genl_family *family;
+
+	bool log_info;
+	bool log_drops;
+	bool log_startup;
+	bool log_error;
 };
 
 struct hwsim_tx_rate {

--- a/wmediumd/wmediumd.h
+++ b/wmediumd/wmediumd.h
@@ -47,6 +47,7 @@
 
 #include <stdint.h>
 #include <stdbool.h>
+#include <syslog.h>
 
 #include "list.h"
 #include "ieee80211.h"
@@ -77,10 +78,7 @@ struct wmediumd {
 	struct nl_cache *cache;
 	struct genl_family *family;
 
-	bool log_info;
-	bool log_drops;
-	bool log_startup;
-	bool log_error;
+	u8 log_lvl;
 };
 
 struct hwsim_tx_rate {
@@ -118,5 +116,7 @@ struct frame {
 
 void station_init_queues(struct station *station);
 double get_error_prob(double snr, unsigned int rate_idx, int frame_len);
+int w_logf(struct wmediumd *ctx, u8 level, const char *format, ...);
+int w_flogf(struct wmediumd *ctx, u8 level, FILE *stream, const char *format, ...);
 
 #endif /* WMEDIUMD_H_ */


### PR DESCRIPTION
A command line option (-l) makes it possible to limit the console output of wmediumd. It is meant to improve wmediumd's performance when using many interfaces and a lot of data.