### PR TITLE
Capture traffic in a separate tmux window

### DIFF
--- a/tests/diamond.sh
+++ b/tests/diamond.sh
@@ -101,8 +101,12 @@ tmux send-keys -t $session:$first_idx '../wmediumd/wmediumd -c diamond.cfg' C-m
 node_idx=$((first_idx + 4))
 tmux send-keys -t $session:$node_idx 'iperf -s' C-m
 
-# enable monitor
-tmux send-keys -t $session:$first_idx 'ip link set hwsim0 up' C-m
+# enable monitor and capture traffic as normal user so that capture file is not
+# owned by root
+tmux new-window -t $session
+cap_idx=$((first_idx + 5))
+tmux send-keys -t $session:$cap_idx 'ip link set hwsim0 up' C-m
+tmux send-keys -t $session:$cap_idx "sudo -u $SUDO_USER dumpcap -i hwsim0" C-m
 
 node_idx=$((first_idx + 1))
 tmux select-window -t $session:$node_idx


### PR DESCRIPTION
In the last commit I tried to reuse a tmux window to bring up the hwsim0
interface. This is not possible as wmediumd stays running on the foreground.

Instead, create a new tmux window to bring up hwsim0 and capture traffic.