### PR TITLE
send frame->freq to the kernel

### DIFF
--- a/wmediumd/wmediumd.c
+++ b/wmediumd/wmediumd.c
@@ -479,7 +479,8 @@ out:
  * Send a data frame to the kernel for reception at a specific radio.
  */
 int send_cloned_frame_msg(struct wmediumd *ctx, struct station *dst,
-			  u8 *data, int data_len, int rate_idx, int signal)
+			  u8 *data, int data_len, int rate_idx, int signal,
+			  int freq)
 {
 	struct nl_msg *msg;
 	struct nl_sock *sock = ctx->sock;
@@ -503,6 +504,7 @@ int send_cloned_frame_msg(struct wmediumd *ctx, struct station *dst,
 		    dst->hwaddr) ||
 	    nla_put(msg, HWSIM_ATTR_FRAME, data_len, data) ||
 	    nla_put_u32(msg, HWSIM_ATTR_RX_RATE, 1) ||
+	    nla_put_u32(msg, HWSIM_ATTR_FREQ, freq) ||
 	    nla_put_u32(msg, HWSIM_ATTR_SIGNAL, -50)) {
 		w_logf(ctx, LOG_ERR, "%s: Failed to fill a payload\n", __func__);
 		ret = -1;
@@ -577,7 +579,8 @@ void deliver_frame(struct wmediumd *ctx, struct frame *frame)
 				send_cloned_frame_msg(ctx, station,
 						      frame->data,
 						      frame->data_len,
-						      1, signal);
+						      1, signal,
+						      frame->freq);
 
 			} else if (memcmp(dest, station->addr, ETH_ALEN) == 0) {
 				if (set_interference_duration(ctx,
@@ -588,7 +591,8 @@ void deliver_frame(struct wmediumd *ctx, struct frame *frame)
 				send_cloned_frame_msg(ctx, station,
 						      frame->data,
 						      frame->data_len,
-						      1, frame->signal);
+						      1, frame->signal,
+						      frame->freq);
 			}
 		}
 	} else


### PR DESCRIPTION
Wmediumd was receiving a wrong list of frequencies from scan command in some Linux kernel versions (e.g. 4.18+). 

Ref: https://p.sipsolutions.net/6c52392b5e31d9d1.txt